### PR TITLE
Don't call inspect on an AR relation

### DIFF
--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -100,7 +100,11 @@ module BetterErrors
     end
 
     def inspect_value(obj)
-      CGI.escapeHTML(obj.inspect)
+      if obj.respond_to?(:to_sql)
+        CGI.escapeHTML("Query: #{obj.send(:to_sql)}")
+      else
+        CGI.escapeHTML(obj.inspect)
+      end
     rescue NoMethodError
       "<span class='unsupported'>(object doesn't support inspect)</span>"
     rescue Exception


### PR DESCRIPTION
If you call inspect on an AR relation if performs a query, which could be very expensive and make it seem like things are hanging...
